### PR TITLE
Added `page.no_hero` to allow skipping hero section.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,9 @@
   {% include head.html %}
   <body>
     {% include header.html %}
-    {% include hero.html %}
+    {% unless page.no_hero %}
+        {% include hero.html %}
+    {% endunless %}
     {% include callouts.html %}
     <section class="section">
         <div class="container">


### PR DESCRIPTION
The current implementation allows setting `page.hero_height`, which can be one of `is-small`, `is-medium`, `is-large`. There is no user option to disable hero completely. This patch adds `page.no_hero`, which when set, completely disables the hero section.